### PR TITLE
Add update Nodejs step to workflow

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -45,6 +45,10 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
+      - name: Update Node and npm
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
Fixes

```bash
Run cd themes/hugo-geekdoc
  cd themes/hugo-geekdoc
  npm install
  npm run build
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    HUGO_VERSION: 0.139.3
    GITHUB_PAGES: true
npm error code EBADENGINE
npm error engine Unsupported engine
npm error engine Not compatible with your version of node/npm: bufferstreams@4.0.0
npm error notsup Not compatible with your version of node/npm: bufferstreams@4.0.0
npm error notsup Required: {"node":">=[2](https://github.com/nodeg/knowledge/actions/runs/12142129427/job/33855847425#step:7:2)0.11.1"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v18.20.5"}
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2024-12-0[3](https://github.com/nodeg/knowledge/actions/runs/12142129427/job/33855847425#step:7:3)T14_48_31_269Z-debug-0.log
```